### PR TITLE
Vertical scoring

### DIFF
--- a/MusicLayerIndicator.gd
+++ b/MusicLayerIndicator.gd
@@ -1,0 +1,32 @@
+extends Node2D
+class_name MusicLayerIndicator
+
+@onready var color_light: Sprite2D = $Sprite2D
+@onready var border: Sprite2D = $Border
+@onready var label: RichTextLabel = $RichTextLabel
+
+var layer: MusicLayer
+
+func show_on():
+	var tween = get_tree().create_tween()
+	tween.tween_property(color_light, "modulate", Color.LIME_GREEN, layer.fade_in_time)
+
+func show_off():
+	var tween = get_tree().create_tween()
+	tween.tween_property(color_light, "modulate", Color.DARK_RED, layer.fade_out_time)
+
+func show_playing():
+	border.modulate = Color.FOREST_GREEN
+
+func show_stopped():
+	border.modulate = Color.DIM_GRAY
+
+func show_paused():
+	border.modulate = Color.CADET_BLUE
+
+func set_layer_name(layer_name: String):
+	label.text = layer_name
+
+func _ready():
+	border.modulate = Color.DIM_GRAY
+	color_light.modulate = Color.DARK_RED	

--- a/TestScene.gd
+++ b/TestScene.gd
@@ -1,0 +1,28 @@
+extends Node
+
+@onready var jukebox: Jukebox = $Jukebox
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	if Input.is_action_just_pressed("Play"):
+		jukebox.play()
+	elif Input.is_action_just_pressed("Pause"):
+		jukebox.pause()
+	elif Input.is_action_just_pressed("Stop"):
+		jukebox.stop()
+
+
+func _on_jukebox_load_complete():
+	print("Jukebox Load complete")
+
+
+func _on_jukebox_song_finished():
+	print("Song finished")
+
+
+func _on_jukebox_song_started():
+	print("Song started")

--- a/TestScene.tscn
+++ b/TestScene.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://235y6u5srbn7"]
+
+[ext_resource type="Script" path="res://TestScene.gd" id="1_np7bj"]
+[ext_resource type="PackedScene" uid="uid://bskhiem623rkr" path="res://jukebox/jukebox.tscn" id="1_pw0go"]
+
+[node name="Node" type="Node"]
+script = ExtResource("1_np7bj")
+
+[node name="Jukebox" parent="." instance=ExtResource("1_pw0go")]
+autoload = true
+playlist_directory = "res://audio"
+autoplay = false
+
+[connection signal="load_complete" from="Jukebox" to="." method="_on_jukebox_load_complete"]
+[connection signal="song_finished" from="Jukebox" to="." method="_on_jukebox_song_finished"]
+[connection signal="song_started" from="Jukebox" to="." method="_on_jukebox_song_started"]

--- a/VerticalScoring/DemoScene.tscn
+++ b/VerticalScoring/DemoScene.tscn
@@ -1,12 +1,20 @@
-[gd_scene load_steps=5 format=3 uid="uid://jwtqe608ur1w"]
+[gd_scene load_steps=6 format=3 uid="uid://jwtqe608ur1w"]
 
 [ext_resource type="Script" path="res://VerticalScoring/DemoVerticalScene.gd" id="1_ykw84"]
 [ext_resource type="PackedScene" uid="uid://cmqfysgnbss0j" path="res://VerticalScoring/VerticalScore.tscn" id="2_hwaue"]
 [ext_resource type="Resource" uid="uid://lgg2m6p1r0l1" path="res://VerticalScoring/SampleLayers/BaseLayer.tres" id="3_0v0wc"]
 [ext_resource type="Resource" uid="uid://ccqmug6enqlkr" path="res://VerticalScoring/SampleLayers/Intensity1.tres" id="4_e6lkm"]
+[ext_resource type="Resource" uid="uid://5hilhqlw6pq0" path="res://VerticalScoring/SampleLayers/Intensity2.tres" id="5_myavy"]
 
 [node name="DemoScene" type="Node"]
 script = ExtResource("1_ykw84")
 
 [node name="VerticalScore" parent="." instance=ExtResource("2_hwaue")]
-layers = [ExtResource("3_0v0wc"), ExtResource("4_e6lkm")]
+layers = Array[Resource("res://VerticalScoring/MusicLayer.gd")]([ExtResource("3_0v0wc"), ExtResource("4_e6lkm"), ExtResource("5_myavy")])
+
+[connection signal="layer_started" from="VerticalScore" to="." method="_on_vertical_score_layer_started"]
+[connection signal="layer_stopped" from="VerticalScore" to="." method="_on_vertical_score_layer_stopped"]
+[connection signal="paused" from="VerticalScore" to="." method="_on_vertical_score_paused"]
+[connection signal="started" from="VerticalScore" to="." method="_on_vertical_score_started"]
+[connection signal="stopped" from="VerticalScore" to="." method="_on_vertical_score_stopped"]
+[connection signal="unpaused" from="VerticalScore" to="." method="_on_vertical_score_unpaused"]

--- a/VerticalScoring/DemoScene.tscn
+++ b/VerticalScoring/DemoScene.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=5 format=3 uid="uid://jwtqe608ur1w"]
+
+[ext_resource type="Script" path="res://VerticalScoring/DemoVerticalScene.gd" id="1_ykw84"]
+[ext_resource type="PackedScene" uid="uid://cmqfysgnbss0j" path="res://VerticalScoring/VerticalScore.tscn" id="2_hwaue"]
+[ext_resource type="Resource" uid="uid://lgg2m6p1r0l1" path="res://VerticalScoring/SampleLayers/BaseLayer.tres" id="3_0v0wc"]
+[ext_resource type="Resource" uid="uid://ccqmug6enqlkr" path="res://VerticalScoring/SampleLayers/Intensity1.tres" id="4_e6lkm"]
+
+[node name="DemoScene" type="Node"]
+script = ExtResource("1_ykw84")
+
+[node name="VerticalScore" parent="." instance=ExtResource("2_hwaue")]
+layers = [ExtResource("3_0v0wc"), ExtResource("4_e6lkm")]

--- a/VerticalScoring/DemoVerticalScene.gd
+++ b/VerticalScoring/DemoVerticalScene.gd
@@ -1,17 +1,64 @@
 extends Node
 
-@onready var vertical_score = $VerticalScore
-# Called when the node enters the scene tree for the first time.
+@onready var vertical_score: VerticalScore = $VerticalScore
+
+var indicator: PackedScene = preload("res://music_layer_indicator.tscn")
+var _layers: Array[MusicLayerIndicator] = []
+
+const _x_increment = 100
+const _y_increment = 100
+
 func _ready():
-	print("Scene loaded")
+	var _next_x = 100
+	for layer in vertical_score.layers:
+		var layer_indicator = indicator.instantiate() as MusicLayerIndicator		
+		layer_indicator.name = "ML_"+layer.name
+		add_child(layer_indicator)		
+		## Really simple layout, and doesn't account for overflowing the screen
+		layer_indicator.position.x = _next_x
+		layer_indicator.position.y = _y_increment
+		layer_indicator.set_layer_name(layer.name)
+		layer_indicator.layer = layer
+		_layers.append(layer_indicator)
+		_next_x += _x_increment	
 
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	if Input.is_action_just_pressed("Play"):
-		vertical_score.play()
-	if Input.is_action_just_pressed("Stop"):
-		vertical_score.fade_out_layer(1)
+		if vertical_score.is_playing():
+			vertical_score.stop()
+		else:
+			vertical_score.play()
 	if Input.is_action_just_pressed("Pause"):
-		vertical_score.fade_in_layer(1)
-		
+		vertical_score._toggle_layer(1)
+	if Input.is_action_just_pressed("Stop"):
+		vertical_score._toggle_layer(2)
+	if Input.is_action_just_pressed("E"):
+		vertical_score.toggle_pause()
+
+func _select_layer(index: int) -> MusicLayerIndicator:
+	if index < 0 || index >= _layers.size():
+		return null
+	return _layers[index]	
+
+func _on_vertical_score_layer_started(index):	
+	_select_layer(index).show_on()
+
+func _on_vertical_score_layer_stopped(index):	
+	_select_layer(index).show_off()
+
+func _on_vertical_score_started():
+	for l in _layers:
+		l.show_playing()
+
+func _on_vertical_score_stopped():
+	for l in _layers:
+		l.show_stopped()
+
+
+func _on_vertical_score_unpaused():
+	for l in _layers:
+		l.show_playing()
+
+func _on_vertical_score_paused():
+	for l in _layers:
+		l.show_paused()

--- a/VerticalScoring/DemoVerticalScene.gd
+++ b/VerticalScoring/DemoVerticalScene.gd
@@ -1,0 +1,17 @@
+extends Node
+
+@onready var vertical_score = $VerticalScore
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	print("Scene loaded")
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	if Input.is_action_just_pressed("Play"):
+		vertical_score.play()
+	if Input.is_action_just_pressed("Stop"):
+		vertical_score.fade_out_layer(1)
+	if Input.is_action_just_pressed("Pause"):
+		vertical_score.fade_in_layer(1)
+		

--- a/VerticalScoring/MusicLayer.gd
+++ b/VerticalScoring/MusicLayer.gd
@@ -2,13 +2,28 @@ extends Resource
 
 class_name MusicLayer
 
+## A MusicLayer is a resource that captures all the data needed to use an
+## audio stream as part of an interactive, vertical score. 
+
+## The name of the layer can be used for interaction and for debugging
+@export var name: String = ""
 
 ## Initial volume of the layer in dB
 @export var target_volume: float = 0.0
+
+## If true, the layer will automatically be set to its target volume when the
+## score is started
 @export var autoplay: bool = false
+
+## The target output bus for the layer. If the bus doesn't exit, it will 
+## default to master
 @export var output_bus_name: String = "Master"
+
+## The audio content of the layer
 @export var audio_stream: AudioStream
+
 ## Time in seconds to fade in to the target_volume
 @export var fade_in_time: float = 0.5
+
 ## Time in seconds to fade out to zero
 @export var fade_out_time: float = 0.5

--- a/VerticalScoring/MusicLayer.gd
+++ b/VerticalScoring/MusicLayer.gd
@@ -1,0 +1,14 @@
+extends Resource
+
+class_name MusicLayer
+
+
+## Initial volume of the layer in dB
+@export var target_volume: float = 0.0
+@export var autoplay: bool = false
+@export var output_bus_name: String = "Master"
+@export var audio_stream: AudioStream
+## Time in seconds to fade in to the target_volume
+@export var fade_in_time: float = 0.5
+## Time in seconds to fade out to zero
+@export var fade_out_time: float = 0.5

--- a/VerticalScoring/MusicLayerPlayer.gd
+++ b/VerticalScoring/MusicLayerPlayer.gd
@@ -1,0 +1,49 @@
+extends Node
+
+class_name MusicLayerPlayer
+
+@export var music_layer: MusicLayer
+
+@onready var audio_stream_player: AudioStreamPlayer = $AudioStreamPlayer
+
+## This is the logical "volume at zero" for audio stream since it uses dbfs
+const _zero_volume := -80.0
+
+const _volume_property := "volume_db"
+
+func mute():
+	audio_stream_player.volume_db = _zero_volume
+
+func start(pos: float = 0.0):
+	audio_stream_player.play(pos)
+	
+func reset_volume():
+	if music_layer.autoplay:
+		audio_stream_player.volume_db = music_layer.target_volume
+	else:
+		audio_stream_player.volume_db = _zero_volume
+	
+func stop():
+	audio_stream_player.stop()
+
+## Sets the audio stream position in seconds. This is needed to synchronize the layer's playback positions
+func seek(position: float):
+	audio_stream_player.seek(position)
+
+func fade_in():
+	var tween = get_tree().create_tween()
+	tween.tween_property(audio_stream_player, _volume_property, music_layer.target_volume, music_layer.fade_in_time)
+	
+func fade_out():
+	var tween = get_tree().create_tween()
+	tween.tween_property(audio_stream_player, _volume_property, -60.0, music_layer.fade_out_time)
+	
+func get_playback_position() -> float:
+	return audio_stream_player.get_playback_position()
+	
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	audio_stream_player.bus = music_layer.output_bus_name
+	if music_layer.audio_stream != null:
+		audio_stream_player.stream = music_layer.audio_stream	
+	audio_stream_player.volume_db = _zero_volume	

--- a/VerticalScoring/MusicLayerPlayer.gd
+++ b/VerticalScoring/MusicLayerPlayer.gd
@@ -2,31 +2,44 @@ extends Node
 
 class_name MusicLayerPlayer
 
+## A MusicLayerPlayer is a wrapper around an AudioStreamPlayer that works
+## with MusicLayers instead of raw AudioStreams. 
+
+## The music layer, which contains the AudioStream and layer data
 @export var music_layer: MusicLayer
 
 @onready var audio_stream_player: AudioStreamPlayer = $AudioStreamPlayer
 
-## This is the logical "volume at zero" for audio stream since it uses dbfs
+## This is the logical "volume at zero" for audio stream in dBfs
 const _zero_volume := -80.0
 
+## Used to tween for fade in/out
 const _volume_property := "volume_db"
 
 func mute():
 	audio_stream_player.volume_db = _zero_volume
 
-func start(pos: float = 0.0):
+func start(pos: float = 0.0):	
 	audio_stream_player.play(pos)
-	
+
+func stop():
+	audio_stream_player.stop()	
+
+## Reset the volume of the layer to its default state
 func reset_volume():
 	if music_layer.autoplay:
 		audio_stream_player.volume_db = music_layer.target_volume
 	else:
 		audio_stream_player.volume_db = _zero_volume
-	
-func stop():
-	audio_stream_player.stop()
 
-## Sets the audio stream position in seconds. This is needed to synchronize the layer's playback positions
+func pause():
+	audio_stream_player.stream_paused = true
+
+func unpause():
+	audio_stream_player.stream_paused = false
+
+## Sets the audio stream position in seconds. This is needed to synchronize the 
+## layer's playback positions
 func seek(position: float):
 	audio_stream_player.seek(position)
 
@@ -43,7 +56,9 @@ func get_playback_position() -> float:
 	
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	audio_stream_player.bus = music_layer.output_bus_name
-	if music_layer.audio_stream != null:
-		audio_stream_player.stream = music_layer.audio_stream	
-	audio_stream_player.volume_db = _zero_volume	
+	audio_stream_player.bus = music_layer.output_bus_name	
+	if music_layer.audio_stream == null:
+		printerr("No audio stream was set for layer ", music_layer.name)
+	else:
+		audio_stream_player.stream = music_layer.audio_stream
+	audio_stream_player.volume_db = _zero_volume

--- a/VerticalScoring/MusicLayerPlayer.tscn
+++ b/VerticalScoring/MusicLayerPlayer.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://d2flc7pm6grv3"]
+
+[ext_resource type="Script" path="res://VerticalScoring/MusicLayerPlayer.gd" id="1_wxtqk"]
+
+[node name="MusicLayerPlayer" type="Node"]
+script = ExtResource("1_wxtqk")
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]

--- a/VerticalScoring/SampleLayers/BaseLayer.tres
+++ b/VerticalScoring/SampleLayers/BaseLayer.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class="MusicLayer" load_steps=3 format=3 uid="uid://lgg2m6p1r0l1"]
+
+[ext_resource type="AudioStream" uid="uid://chl6ddrsvwvq2" path="res://audio/06 Lullaby.wav" id="1_33w25"]
+[ext_resource type="Script" path="res://VerticalScoring/MusicLayer.gd" id="1_dfrxd"]
+
+[resource]
+script = ExtResource("1_dfrxd")
+target_volume = 0.0
+autoplay = true
+output_bus_name = "Master"
+audio_stream = ExtResource("1_33w25")
+fade_in_time = 0.5
+fade_out_time = 0.5

--- a/VerticalScoring/SampleLayers/Intensity1.tres
+++ b/VerticalScoring/SampleLayers/Intensity1.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class="MusicLayer" load_steps=3 format=3 uid="uid://ccqmug6enqlkr"]
+
+[ext_resource type="Script" path="res://VerticalScoring/MusicLayer.gd" id="1_crfb5"]
+[ext_resource type="AudioStream" uid="uid://df7dg5uy6xr7g" path="res://audio/07 Dreamland.wav" id="1_vyvrj"]
+
+[resource]
+script = ExtResource("1_crfb5")
+target_volume = 0.0
+autoplay = false
+output_bus_name = "Master"
+audio_stream = ExtResource("1_vyvrj")
+fade_in_time = 0.5
+fade_out_time = 0.5

--- a/VerticalScoring/VerticalScore.gd
+++ b/VerticalScoring/VerticalScore.gd
@@ -1,49 +1,132 @@
 extends Node
+class_name VerticalScore
+## A VerticalScore represents a single musical event that is composed of multiple layers.
+## Layers can be faded in and out individually while the score is playing, and the
+## playback positions will remain synchronized across all layers
+##
+## A layer is defined by a resource file that contains the audio stream for that layers, as well as
+## additional metadata
 
-@export var layers = []
+signal started
+signal stopped
+signal paused
+signal unpaused
+signal layer_started(index: int)
+signal layer_stopped(index: int)
+
+## The layers available in this score
+@export var layers: Array[MusicLayer] = []
+
+## When true, the score will start playing on ready
 @export var autoplay: bool = false
 
-var _layer_players = []
+var _is_paused: bool = false
+var _layer_players: Array[MusicLayerPlayer] = []
 var _layer_scene: PackedScene = preload("res://VerticalScoring/MusicLayerPlayer.tscn")
+var _layer_toggles = {}
+var _is_playing: bool = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	for layer in layers:
-		var l: MusicLayer = layer as MusicLayer
-		var layer_player = _layer_scene.instantiate() as MusicLayerPlayer
-		layer_player.music_layer = l
-		add_child(layer_player)
-		layer_player.stop()	
-		layer_player.reset_volume()
-		_layer_players.append(layer_player)
+		_layer_players.append(_create_layer_player(layer))
+	print("Vertical score: ", _layer_players.size(), " layers available")
+
+
+func num_layers() -> int:
+	return _layer_players.size()
 
 func fade_in_layer(layer_index: int):
 	if layer_index >= layers.size():
 		return
-	var l: MusicLayerPlayer = _layer_players[layer_index] as MusicLayerPlayer
-	l.fade_in()
+	_layer_players[layer_index].fade_in()
+	layer_started.emit(layer_index)
 
 func fade_out_layer(layer_index: int):
 	if layer_index >= layers.size():
 		return
-	var l: MusicLayerPlayer = _layer_players[layer_index] as MusicLayerPlayer
-	l.fade_out()
+	_layer_players[layer_index].fade_out()	
+	layer_stopped.emit(layer_index)
+
+func is_playing() -> bool:
+	return _is_playing
 
 func play():
-	var index = 0
-	for layer in _layer_players:
-		var l = layer as MusicLayerPlayer
-		if index > 0:
-			l.start((_layer_players[index-1] as MusicLayerPlayer).get_playback_position())
-		else:
-			l.start()
-		index += 1
+	_is_paused = false
+	if _layer_players.is_empty():
+		return
+	
+	var source = _layer_players[0]
+	source.start()
+	layer_started.emit(0)
+	
+	if _layer_players.size() == 1:
+		return
+	for i in range(1, _layer_players.size()):
+			_layer_players[i].start(source.get_playback_position())
+			if layers[i].autoplay:
+				fade_in_layer(i)
+	
+	_is_playing = true
+	started.emit()
 
 func stop():
+	_is_paused = false
 	for layer in _layer_players:
 		var l = layer as MusicLayerPlayer
 		l.stop()
+	_is_playing = false
+	stopped.emit()
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
+
+func _synchronize_layers():
+	if _layer_players.size() == 1:
+		return
+	
+	var source = _layer_players[0]
+	for i in range(1, _layer_players.size()):
+		_layer_players[i].seek(source.get_playback_position())
+
+func toggle_pause():
+	if !_is_playing:
+		return
+		
+	if _is_paused:
+		_synchronize_layers()
+		for l in _layer_players:
+			l.unpause()
+		_is_paused = false
+		unpaused.emit()
+	else:
+		for l in _layer_players:
+			l.pause()
+		_is_paused = true
+		paused.emit()
+
+func _reset_layer(l: MusicLayerPlayer):
+	l.stop()
+	l.reset_volume()
+
+func _create_layer_player(l: MusicLayer) -> MusicLayerPlayer:		
+	var layer_player = _layer_scene.instantiate() as MusicLayerPlayer
+	layer_player.name = "MLP_"+l.name
+	layer_player.music_layer = l
+	add_child(layer_player)
+	_reset_layer(layer_player)
+	return layer_player
+
+func _reset_layers():	
+	for layer in _layer_players:
+		_reset_layer(layer)
+
+func _toggle_layer(i: int):
+	if _layer_toggles.has(i):
+		_layer_toggles[i] = !_layer_toggles[i]
+		if _layer_toggles[i]:
+			fade_in_layer(i)
+		else:
+			fade_out_layer(i)
+	else:
+		_layer_toggles[i] = true
+		fade_in_layer(i)
+

--- a/VerticalScoring/VerticalScore.gd
+++ b/VerticalScoring/VerticalScore.gd
@@ -1,0 +1,49 @@
+extends Node
+
+@export var layers = []
+@export var autoplay: bool = false
+
+var _layer_players = []
+var _layer_scene: PackedScene = preload("res://VerticalScoring/MusicLayerPlayer.tscn")
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	for layer in layers:
+		var l: MusicLayer = layer as MusicLayer
+		var layer_player = _layer_scene.instantiate() as MusicLayerPlayer
+		layer_player.music_layer = l
+		add_child(layer_player)
+		layer_player.stop()	
+		layer_player.reset_volume()
+		_layer_players.append(layer_player)
+
+func fade_in_layer(layer_index: int):
+	if layer_index >= layers.size():
+		return
+	var l: MusicLayerPlayer = _layer_players[layer_index] as MusicLayerPlayer
+	l.fade_in()
+
+func fade_out_layer(layer_index: int):
+	if layer_index >= layers.size():
+		return
+	var l: MusicLayerPlayer = _layer_players[layer_index] as MusicLayerPlayer
+	l.fade_out()
+
+func play():
+	var index = 0
+	for layer in _layer_players:
+		var l = layer as MusicLayerPlayer
+		if index > 0:
+			l.start((_layer_players[index-1] as MusicLayerPlayer).get_playback_position())
+		else:
+			l.start()
+		index += 1
+
+func stop():
+	for layer in _layer_players:
+		var l = layer as MusicLayerPlayer
+		l.stop()
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/VerticalScoring/VerticalScore.tscn
+++ b/VerticalScoring/VerticalScore.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://cmqfysgnbss0j"]
+
+[ext_resource type="Script" path="res://VerticalScoring/VerticalScore.gd" id="1_fsoef"]
+
+[node name="VerticalScore" type="Node"]
+script = ExtResource("1_fsoef")
+layers = null
+autoplay = null

--- a/VerticalScoring/VerticalScore.tscn
+++ b/VerticalScoring/VerticalScore.tscn
@@ -4,5 +4,3 @@
 
 [node name="VerticalScore" type="Node"]
 script = ExtResource("1_fsoef")
-layers = null
-autoplay = null

--- a/music_layer_indicator.tscn
+++ b/music_layer_indicator.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=6 format=3 uid="uid://dvq8w241p7vhp"]
+
+[ext_resource type="Script" path="res://MusicLayerIndicator.gd" id="1_sncag"]
+
+[sub_resource type="Gradient" id="Gradient_jnce4"]
+offsets = PackedFloat32Array(1)
+colors = PackedColorArray(1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_8saow"]
+gradient = SubResource("Gradient_jnce4")
+
+[sub_resource type="Gradient" id="Gradient_j2ri5"]
+offsets = PackedFloat32Array(0)
+colors = PackedColorArray(1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_ikmop"]
+gradient = SubResource("Gradient_j2ri5")
+
+[node name="MusicLayerIndicator" type="Node2D"]
+script = ExtResource("1_sncag")
+
+[node name="Border" type="Sprite2D" parent="."]
+scale = Vector2(1.25197, 1.25197)
+texture = SubResource("GradientTexture2D_8saow")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = SubResource("GradientTexture2D_ikmop")
+
+[node name="RichTextLabel" type="RichTextLabel" parent="."]
+offset_left = -52.0
+offset_top = 40.0
+offset_right = 55.0
+offset_bottom = 80.0


### PR DESCRIPTION
Adds the following scripts and scenes:
* Music Layer - A resource that describes a layer in a vertical score and holds an audio stream
* Music Layer Player - A scene with an AudioStreamPlayer. Provides some abstraction to work with loading a music layer and getting the audio data into a player and to the correct output bus
* Vertical score - A scene that can be loaded with an array of layers, and then provides mechanisms to fade in/out different layers and start/stop the whole score while keeping all the layers synchronized
* MusicLayerIndicator - Just for debugging, a small scene with some visual indicators on the state of a layer
* DemoScene - An example of using a vertical score in practice. Dynamically reads the layers in the vertical score node and creates MusicLayerIndicators for each
